### PR TITLE
Add CLI flags to control include/exclude of the various change types

### DIFF
--- a/diff/printer/std.go
+++ b/diff/printer/std.go
@@ -11,13 +11,21 @@ import (
 
 // StdPrinter uses a textual description for diffs.
 type StdPrinter struct {
-	w io.Writer
+	w         io.Writer
+	unchanged bool
+	updated   bool
+	created   bool
+	deleted   bool
 }
 
 // NewStdPrinter creates a new StdPrinter.
-func NewStdPrinter(w io.WriteCloser) *StdPrinter {
+func NewStdPrinter(w io.WriteCloser, unchanged, updated, created, deleted bool) *StdPrinter {
 	return &StdPrinter{
-		w: w,
+		w:         w,
+		unchanged: unchanged,
+		updated:   updated,
+		created:   created,
+		deleted:   deleted,
 	}
 }
 
@@ -26,13 +34,21 @@ func NewStdPrinter(w io.WriteCloser) *StdPrinter {
 func (p *StdPrinter) Print(d diff.Diff) error {
 	switch d.Mode {
 	case diff.Unchanged:
-		// fmt.Fprintf(p.w, "-\t%v\n", cmp.Diff(d.Src, d.Dst))
+		if p.unchanged {
+			fmt.Fprintf(p.w, "Unchanged\t%v\n", cmp.Diff(d.Src, d.Dst))
+		}
 	case diff.Created:
-		fmt.Fprintf(p.w, "Created\t%v\t%v\n", d.Dst.ID, cmp.Diff(d.Src, d.Dst))
+		if p.created {
+			fmt.Fprintf(p.w, "Created\t%v\t%v\n", d.Dst.ID, cmp.Diff(d.Src, d.Dst))
+		}
 	case diff.Updated:
-		fmt.Fprintf(p.w, "Updated\t%v\t%v\n", d.Src.ID, cmp.Diff(d.Src, d.Dst))
+		if p.updated {
+			fmt.Fprintf(p.w, "Updated\t%v\t%v\n", d.Src.ID, cmp.Diff(d.Src, d.Dst))
+		}
 	case diff.Deleted:
-		fmt.Fprintf(p.w, "Deleted\t%v\n", d.Src.ID)
+		if p.deleted {
+			fmt.Fprintf(p.w, "Deleted\t%v\n", d.Src.ID)
+		}
 	}
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -28,7 +28,12 @@ func main() {
 		size         = flag.Int("size", 100, "Batch size")
 		rawSrcFilter = flag.String("sf", "", `Raw query for filtering the source, e.g. {"term":{"user":"olivere"}}`)
 		rawDstFilter = flag.String("df", "", `Raw query for filtering the destination, e.g. {"term":{"name.keyword":"Oliver"}}`)
+		unchanged    = flag.Bool("u", false, `Should unchanged docs be included?`)
+		updated      = flag.Bool("c", false, `Should changed docs be included?`)
+		changed      = flag.Bool("a", false, `Should added docs be included?`)
+		deleted      = flag.Bool("d", false, `Should deleted docs be included?`)
 	)
+
 	log.SetFlags(0)
 	flag.Usage = usage
 	flag.Parse()
@@ -58,13 +63,17 @@ func main() {
 		RawQuery: *rawDstFilter,
 	}
 
+	if !*unchanged && !*updated && !*changed && !*deleted {
+		*unchanged, *updated, *changed, *deleted = true, true, true, true
+	}
+
 	var p printer.Printer
 	{
 		switch *outputFormat {
 		default:
-			p = printer.NewStdPrinter(os.Stdout)
+			p = printer.NewStdPrinter(os.Stdout, *unchanged, *updated, *changed, *deleted)
 		case "json":
-			p = printer.NewJSONPrinter(os.Stdout, -1, 0)
+			p = printer.NewJSONPrinter(os.Stdout, *unchanged, *updated, *changed, *deleted)
 		}
 	}
 


### PR DESCRIPTION
Thanks for `esdiff` - it's really quick and easy to use.

We'd like to be able to control which types of event (unchanged/updated/created/deleted) get included in
the output - unchanged being in the .json output format makes for very large files.

Happy for any changes you see fit - I'm new to go and this is probably a clumsy initial implementation.